### PR TITLE
Partial rewrite of getPreviewBitmap

### DIFF
--- a/PhotonFile.py
+++ b/PhotonFile.py
@@ -437,63 +437,62 @@ class PhotonFile:
                 binary_file.write(self.LayerData[lNr]["Raw"])
                 binary_file.write(self.LayerData[lNr]["EndOfLayer"])
 
+    def getPreviewBitmap(self, prevNr):
+            #https://github.com/Reonarudo/pcb2photon/issues/2
 
-def getPreviewBitmap(self, prevNr):
-        #https://github.com/Reonarudo/pcb2photon/issues/2
+            self.isDrawing = True
+            w = PhotonFile.bytes_to_int(self.Previews[prevNr]["Resolution X"])
+            h = PhotonFile.bytes_to_int(self.Previews[prevNr]["Resolution Y"])
+            s = PhotonFile.bytes_to_int(self.Previews[prevNr]["Data Length"])
+            scale = ((1440/4)/w, (1440/4)/w)
+            memory = pygame.Surface((int(w), int(h)))
+            if w==0 or h==0: return memory
+            bA = self.Previews[prevNr]["Image Data"]
 
-        self.isDrawing = True
-        w = PhotonFile.bytes_to_int(self.Previews[prevNr]["Resolution X"])
-        h = PhotonFile.bytes_to_int(self.Previews[prevNr]["Resolution Y"])
-        s = PhotonFile.bytes_to_int(self.Previews[prevNr]["Data Length"])
-        scale = ((1440/4)/w, (1440/4)/w)
-        memory = pygame.Surface((int(w), int(h)))
-        if w==0 or h==0: return memory
-        bA = self.Previews[prevNr]["Image Data"]
-
-        # Seek position and read N bytes
-        idx=0
-        pixelIdx = 0
-        while idx<len(bA):
-            # The color of a pixel is 2 bytes (little endian) with each bit like this: RRRRR GGG GG X BBBBB
-            b12 = bA[idx+1]<<8 | bA[idx+0]
-            idx += 2
-            red  =math.floor(((b12>>11) & 0x1F) / 31*255)
-            green=math.floor(((b12>> 6) & 0x1F) / 31*255)
-            blue= math.floor(((b12>> 0) & 0x1F) / 31*255)
-            col = (red, green, blue)
-
-            #red   =  b1>>3
-            #green = (b1 & 0b00000111) <<2 | (b2 & 0b11000000)>>6
-            #blue  =  b2 & 0b00011111
-
-            #isRep = (b2 & 0b00100000) >> 5
-
-
-            # If the X bit is set, then the next 2 bytes (little endian) masked with 0xFFF represents how many more times to repeat that pixel.
-            nr=1
-            if b12 & 0x20:
-                nr12 = bA[idx + 1] << 8 | bA[idx + 0]
+            # Seek position and read N bytes
+            idx=0
+            pixelIdx = 0
+            while idx<len(bA):
+                # The color of a pixel is 2 bytes (little endian) with each bit like this: RRRRR GGG GG X BBBBB
+                b12 = bA[idx+1]<<8 | bA[idx+0]
                 idx += 2
-                nr += nr12 & 0x0FFF
+                red  =math.floor(((b12>>11) & 0x1F) / 31*255)
+                green=math.floor(((b12>> 6) & 0x1F) / 31*255)
+                blue= math.floor(((b12>> 0) & 0x1F) / 31*255)
+                col = (red, green, blue)
 
-            # Draw (nr) many pixels of the color
-            for i in range(0, nr, 1):
-                x = int((pixelIdx % w))
-                y = int((pixelIdx / w))
-                memory.set_at((x, y), col)
-                pixelIdx += 1
+                #red   =  b1>>3
+                #green = (b1 & 0b00000111) <<2 | (b2 & 0b11000000)>>6
+                #blue  =  b2 & 0b00011111
 
-            
-    
-        #print("Screen Drawn")
-        # debug print ("layer: ", layerNr)
-        # debug print ("lastByte:", self.LayerData[layerNr]["EndOfLayer"])
+                #isRep = (b2 & 0b00100000) >> 5
 
-        # Scale the surface to the wanted resolution
-        memory = pygame.transform.scale(memory, (int(w*scale[0]), int(h*scale[1])))
 
-        self.isDrawing = False
-        return memory
+                # If the X bit is set, then the next 2 bytes (little endian) masked with 0xFFF represents how many more times to repeat that pixel.
+                nr=1
+                if b12 & 0x20:
+                    nr12 = bA[idx + 1] << 8 | bA[idx + 0]
+                    idx += 2
+                    nr += nr12 & 0x0FFF
+
+                # Draw (nr) many pixels of the color
+                for i in range(0, nr, 1):
+                    x = int((pixelIdx % w))
+                    y = int((pixelIdx / w))
+                    memory.set_at((x, y), col)
+                    pixelIdx += 1
+
+                
+        
+            #print("Screen Drawn")
+            # debug print ("layer: ", layerNr)
+            # debug print ("lastByte:", self.LayerData[layerNr]["EndOfLayer"])
+
+            # Scale the surface to the wanted resolution
+            memory = pygame.transform.scale(memory, (int(w*scale[0]), int(h*scale[1])))
+
+            self.isDrawing = False
+            return memory
 
 
 '''


### PR DESCRIPTION
I've partially rewritten getPreviewBitmap to more closely match 
https://github.com/Rob2048/PhotonTool/blob/master/index.html#L246-L294 and https://github.com/Andoryuuta/photon/blob/master/preview_image.go#L9-L63

Fixes: https://github.com/NardJ/PhotonFileUtils/issues/12

Preview 0: 
![image](https://user-images.githubusercontent.com/8594162/41700536-7c1dc19a-74dd-11e8-9592-678572ba6efc.png)

Preview 1:
![image](https://user-images.githubusercontent.com/8594162/41700548-84ca40de-74dd-11e8-967e-6b7473386815.png)

